### PR TITLE
Removes await Parent

### DIFF
--- a/packages/sveltekit-meta/src/lib/components/Mount.svelte
+++ b/packages/sveltekit-meta/src/lib/components/Mount.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { page } from '$app/state'
 	import { afterNavigate } from '$app/navigation'
+	import { mergeMetadataObjects } from './merge'
 
-	let metaTags = $state(page.data.metaTags)
+	let metaTags = $state.frozen(mergeMetadataObjects(page.data, page.route.id || '/'))
 
 	afterNavigate(() => {
-		metaTags = page.data.metaTags
+		metaTags = mergeMetadataObjects(page.data, page.route.id || '/')
 	})
 
 	let combinedTitle = $derived.by(() => {

--- a/packages/sveltekit-meta/src/lib/components/merge.ts
+++ b/packages/sveltekit-meta/src/lib/components/merge.ts
@@ -1,0 +1,100 @@
+import type { Metadata, ParentMetadata } from '../types/metadata'
+
+// Generate a short UUID (12 characters)
+function generateShortUUID(): string {
+	return Math.random().toString(36).substring(2, 14)
+}
+
+// Create a metadata object with route info
+export function createMetadataObject(routeId: string, metadata: Metadata) {
+	const uuid = generateShortUUID()
+	return {
+		id: `${uuid}.${routeId}`,
+		routeId,
+		metadata
+	}
+}
+
+// Parse route segments to determine hierarchy
+function parseRouteSegments(routeId: string): string[] {
+	// Handle root route
+	if (routeId === '/') {
+		return ['/']
+	}
+	
+	// Remove leading slash and split by '/'
+	const segments = routeId.replace(/^\//, '').split('/').filter(Boolean)
+	const hierarchy: string[] = ['/'] // Always start with root
+	
+	// Build hierarchy from root to current route
+	for (let i = 0; i < segments.length; i++) {
+		if (i === 0) {
+			hierarchy.push(`/${segments[i]}`)
+		} else {
+			hierarchy.push(hierarchy[i] + '/' + segments[i])
+		}
+	}
+	
+	return hierarchy
+}
+
+// Merge metadata following the same logic as the original parseMeta
+function mergeMetadata(parentTags: ParentMetadata | null, setTags: Metadata): ParentMetadata {
+	// Handle character limit warnings
+	if (setTags.title && setTags.title.length > 70) {
+		console.warn('Title exceeds recommended length of 70 characters')
+	}
+
+	if (setTags.description && setTags.description.length > 200) {
+		console.warn('Description exceeds recommended length of 200 characters')
+	}
+
+	// Handle mutual exclusivity for image/images
+	if ('image' in setTags && 'images' in setTags) {
+		console.warn('Both image and images properties specified - using images and ignoring image')
+		const { image, ...restData } = setTags
+		setTags = restData
+	}
+
+	// Handle mutual exclusivity for video/videos
+	if ('video' in setTags && 'videos' in setTags) {
+		console.warn('Both video and videos properties specified - using videos and ignoring video')
+		const { video, ...restData } = setTags
+		setTags = restData
+	}
+
+	// Handle titles and title templates
+	let safeParentTags: Partial<ParentMetadata> = parentTags ? { ...parentTags } : {}
+	if (safeParentTags.titleTemplate) {
+		safeParentTags.parentTitleTemplate = safeParentTags.titleTemplate
+		delete safeParentTags?.titleTemplate
+	}
+
+	return { ...safeParentTags, ...setTags } as ParentMetadata
+}
+
+// Main function to merge all metadata objects based on route hierarchy
+export function mergeMetadataObjects(metadataObjects: Record<string, any>, currentRouteId: string): ParentMetadata {
+	// Get all metadata objects
+	const allObjects = Object.values(metadataObjects).filter(obj => obj && obj.id && obj.routeId && obj.metadata)
+	
+	// Get the route hierarchy for the current route
+	const hierarchy = parseRouteSegments(currentRouteId)
+	
+	// Sort metadata objects based on route hierarchy
+	const sortedObjects = allObjects
+		.filter(obj => hierarchy.includes(obj.routeId))
+		.sort((a, b) => {
+			const aIndex = hierarchy.indexOf(a.routeId)
+			const bIndex = hierarchy.indexOf(b.routeId)
+			return aIndex - bIndex
+		})
+	
+	// Merge metadata following the waterfall pattern
+	let result: ParentMetadata = {}
+	for (const obj of sortedObjects) {
+		result = mergeMetadata(result, obj.metadata) as ParentMetadata
+	}
+	
+	return result
+}


### PR DESCRIPTION
Currently, this tool relies on load functions awaiting parent data in order to merge the meta data at each step along loaded data flow (from top to bottom). This results in performance degradation as SvelteKit can no longer properly run load functions in parallel. This new version takes a new approach. Wherever meta data is set, it creates a new object on the load data with its route id (including groups), prefixed by ‘meta_’. Then in our mount component, we use a merge function to look at routes and do the same inteligent shallow merging we did previously. This should all result in better performance and contribute to simpler usage. I think if this change performs as expected, then the next step would be to take another look at the API here and see if there is room for simplification. But need to test this change thoroughly to make sure that it is functioning as expected